### PR TITLE
Reduce homepage font sizes by one step (preview)

### DIFF
--- a/myblog/src/pages/index.astro
+++ b/myblog/src/pages/index.astro
@@ -10,22 +10,22 @@ import Layout from '../layouts/Layout.astro';
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-8">
           <div class="relative flex-grow">
             <div class="flex items-start gap-2 mb-4">
-              <h1 class="font-zt text-[2.5rem] sm:text-6xl font-black tracking-tight leading-[1.4] relative text-black dark:text-white py-2">
+              <h1 class="font-zt text-[2rem] sm:text-5xl font-black tracking-tight leading-[1.4] relative text-black dark:text-white py-2">
                 Hey, I'm Gagan
               </h1>
               <div class="flex-shrink-0 sm:hidden">
                 <div class="relative w-24 h-24 rounded-full overflow-hidden border-4 border-stone-300/30 dark:border-stone-600/30 shadow-[0_0_20px_rgba(0,0,0,0.3)] dark:shadow-[0_0_20px_rgba(192,192,192,0.4)] -mt-3 ml-1">
-                    <img 
-                      src="/images/bhairav.jpg" 
-                      alt="Gagan's profile picture" 
+                    <img
+                      src="/images/bhairav.jpg"
+                      alt="Gagan's profile picture"
                       class="w-full h-full object-cover"
                     />
                 </div>
               </div>
             </div>
-            <p class="font-space text-stone-600 dark:text-stone-400 text-base sm:text-lg leading-relaxed max-w-2xl -mt-1 sm:mt-0">
-              tldr: 19 y/o sophomore majoring in CS. I build cool stuff and make machines learn. 
-              I write about machine learning, tech, and topics that grab my curiosity. 
+            <p class="font-space text-stone-600 dark:text-stone-400 text-sm sm:text-base leading-relaxed max-w-2xl -mt-1 sm:mt-0">
+              tldr: 19 y/o sophomore majoring in CS. I build cool stuff and make machines learn.
+              I write about machine learning, tech, and topics that grab my curiosity.
               <!-- <span class="text-stone-800 dark:text-stone-200 font-medium">Building things and sharing it out along the way :)</span>-->
               <span class="text-stone-800 dark:text-stone-200 font-medium">Building Your Personal AI Tutor -</span>
               <a href="https://ztutor.app" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 font-medium hover:underline">zTutor!</a>
@@ -35,25 +35,25 @@ import Layout from '../layouts/Layout.astro';
             </p>
             <div class="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-6 mt-8 sm:mt-10">
               <div class="flex gap-3 sm:gap-4">
-                <a 
-                  href="/blogs" 
-                  class="inline-flex items-center justify-center font-space text-sm px-4 sm:px-5 py-2 sm:py-2.5 bg-gradient-to-r from-stone-800 to-stone-900 dark:from-stone-200 dark:to-stone-100 text-white dark:text-stone-900 rounded-lg hover:from-stone-900 hover:to-black dark:hover:from-stone-100 dark:hover:to-white transition-all duration-300 shadow-sm hover:shadow-md relative overflow-hidden group"
+                <a
+                  href="/blogs"
+                  class="inline-flex items-center justify-center font-space text-xs px-4 sm:px-5 py-2 sm:py-2.5 bg-gradient-to-r from-stone-800 to-stone-900 dark:from-stone-200 dark:to-stone-100 text-white dark:text-stone-900 rounded-lg hover:from-stone-900 hover:to-black dark:hover:from-stone-100 dark:hover:to-white transition-all duration-300 shadow-sm hover:shadow-md relative overflow-hidden group"
                 >
                   <span class="relative z-10">Read My Blogs</span>
                   <span class="absolute inset-0 bg-gradient-to-r from-stone-900 to-black dark:from-stone-100 dark:to-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
                 </a>
-                <a 
-                  href="/project" 
-                  class="font-space text-sm px-4 sm:px-5 py-2 sm:py-2.5 border-2 border-stone-300 dark:border-stone-600 text-stone-700 dark:text-stone-300 rounded-lg hover:bg-stone-50 dark:hover:bg-stone-800/20 hover:border-stone-400 dark:hover:border-stone-500 transition-all duration-300 relative overflow-hidden group"
+                <a
+                  href="/project"
+                  class="font-space text-xs px-4 sm:px-5 py-2 sm:py-2.5 border-2 border-stone-300 dark:border-stone-600 text-stone-700 dark:text-stone-300 rounded-lg hover:bg-stone-50 dark:hover:bg-stone-800/20 hover:border-stone-400 dark:hover:border-stone-500 transition-all duration-300 relative overflow-hidden group"
                 >
                   <span class="relative z-10">View Projects</span>
                   <span class="absolute inset-0 bg-stone-50 dark:bg-stone-800/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
                 </a>
               </div>
               <div class="flex gap-4">
-                <a 
-                  href="https://github.com/Gagancreates" 
-                  target="_blank" 
+                <a
+                  href="https://github.com/Gagancreates"
+                  target="_blank"
                   rel="noopener noreferrer"
                   class="text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 transition-colors relative group"
                   aria-label="GitHub"
@@ -63,9 +63,9 @@ import Layout from '../layouts/Layout.astro';
                   </svg>
                   <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 group-hover:w-full transition-all duration-300"></span>
                 </a>
-                <a 
-                  href="" 
-                  target="_blank" 
+                <a
+                  href=""
+                  target="_blank"
                   rel="noopener noreferrer"
                   class="text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 transition-colors relative group"
                   aria-label="Twitter"
@@ -75,9 +75,9 @@ import Layout from '../layouts/Layout.astro';
                   </svg>
                   <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 group-hover:w-full transition-all duration-300"></span>
                 </a>
-                <a 
-                  href="https://www.linkedin.com/in/gaganp56/" 
-                  target="_blank" 
+                <a
+                  href="https://www.linkedin.com/in/gaganp56/"
+                  target="_blank"
                   rel="noopener noreferrer"
                   class="text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 transition-colors relative group"
                   aria-label="LinkedIn"
@@ -92,9 +92,9 @@ import Layout from '../layouts/Layout.astro';
           </div>
           <div class="flex-shrink-0 mx-auto sm:mx-0 -mt-4 sm:-mt-8 hidden sm:block">
             <div class="relative w-24 h-24 sm:w-56 sm:h-56 rounded-full overflow-hidden border-4 border-stone-300/30 dark:border-stone-600/30 shadow-[0_0_20px_rgba(0,0,0,0.3)] dark:shadow-[0_0_20px_rgba(192,192,192,0.4)]">
-  <img 
-    src="/images/bhairav.jpg" 
-    alt="Gagan's profile picture" 
+  <img
+    src="/images/bhairav.jpg"
+    alt="Gagan's profile picture"
     class="w-full h-full object-cover"
   />
 </div>
@@ -105,12 +105,12 @@ import Layout from '../layouts/Layout.astro';
       <!-- Content Sections -->
       <div class="space-y-12 sm:space-y-24 w-full">
         <!-- Experience Section -->
-        <section class="group relative p-6 sm:p-8 rounded-2xl 
+        <section class="group relative p-6 sm:p-8 rounded-2xl
           bg-gradient-to-br from-rose-50/80 via-white to-rose-100/60
           shadow-[0_15px_35px_-5px_rgb(0,0,0,0.1)]
           border border-rose-300
           backdrop-blur-sm
-          dark:from-stone-900/60 dark:to-stone-800/40 
+          dark:from-stone-900/60 dark:to-stone-800/40
           dark:border-stone-500/60
           hover:shadow-lg hover:border-rose-400 dark:hover:border-stone-500/75 transition-all duration-500 mt-4 sm:mt-12">
           <div class="absolute -top-4 -left-4 w-20 h-20 bg-gradient-to-br from-stone-100/20 to-transparent rounded-full blur-lg dark:from-stone-800/15" />
@@ -118,7 +118,7 @@ import Layout from '../layouts/Layout.astro';
           <div class="absolute inset-0 bg-gradient-to-br from-stone-50/20 to-transparent dark:from-stone-900/15 rounded-2xl" />
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 mb-4 sm:mb-8">
             <div class="flex items-center gap-2 sm:gap-3">
-              <h2 class="font-zt text-2xl sm:text-3xl relative group">
+              <h2 class="font-zt text-xl sm:text-2xl relative group">
                 <span class="relative z-10 text-stone-900 dark:text-stone-100">Experience</span>
                 <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
               </h2>
@@ -136,7 +136,7 @@ import Layout from '../layouts/Layout.astro';
                 />
               </div>
               <div class="sm:hidden flex-1">
-                <h3 class="font-space text-base font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-sm font-medium text-stone-900 dark:text-stone-100">
                   AI Engineer
                 </h3>
                 <span class="font-mono text-xs text-stone-500 dark:text-stone-400">
@@ -146,14 +146,14 @@ import Layout from '../layouts/Layout.astro';
             </div>
             <div class="flex-grow">
               <div class="hidden sm:flex flex-row items-center justify-between gap-2 mb-1">
-                <h3 class="font-space text-lg sm:text-xl font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-base sm:text-lg font-medium text-stone-900 dark:text-stone-100">
                   AI Engineer
                 </h3>
-                <span class="font-mono text-sm text-stone-500 dark:text-stone-400 whitespace-nowrap">
+                <span class="font-mono text-xs text-stone-500 dark:text-stone-400 whitespace-nowrap">
                   Present
                 </span>
               </div>
-              <p class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
+              <p class="font-space text-xs sm:text-sm text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
                 Rowboat Labs (YC S24)
               </p>
             </div>
@@ -170,7 +170,7 @@ import Layout from '../layouts/Layout.astro';
                 />
               </div>
               <div class="sm:hidden flex-1">
-                <h3 class="font-space text-base font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-sm font-medium text-stone-900 dark:text-stone-100">
                   Founder
                 </h3>
                 <span class="font-mono text-xs text-stone-500 dark:text-stone-400">
@@ -180,17 +180,17 @@ import Layout from '../layouts/Layout.astro';
             </div>
             <div class="flex-grow">
               <div class="hidden sm:flex flex-row items-center justify-between gap-2 mb-1">
-                <h3 class="font-space text-lg sm:text-xl font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-base sm:text-lg font-medium text-stone-900 dark:text-stone-100">
                   Founder
                 </h3>
-                <span class="font-mono text-sm text-stone-500 dark:text-stone-400 whitespace-nowrap">
+                <span class="font-mono text-xs text-stone-500 dark:text-stone-400 whitespace-nowrap">
                   June 2025 - April 2026
                 </span>
               </div>
-              <p class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
+              <p class="font-space text-xs sm:text-sm text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
                 zTutor: Your Personal AI Video Tutor
               </p>
-              <p class="font-space text-sm text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
+              <p class="font-space text-xs text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
                 AI-powered educational video platform from 0→1. 2000+ videos generated, backed by 3F Venture Capital.
               </p>
             </div>
@@ -207,7 +207,7 @@ import Layout from '../layouts/Layout.astro';
                 />
               </div>
               <div class="sm:hidden flex-1">
-                <h3 class="font-space text-base font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-sm font-medium text-stone-900 dark:text-stone-100">
                   Subject Matter Expert
                 </h3>
                 <span class="font-mono text-xs text-stone-500 dark:text-stone-400">
@@ -217,17 +217,17 @@ import Layout from '../layouts/Layout.astro';
             </div>
             <div class="flex-grow">
               <div class="hidden sm:flex flex-row items-center justify-between gap-2 mb-1">
-                <h3 class="font-space text-lg sm:text-xl font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-base sm:text-lg font-medium text-stone-900 dark:text-stone-100">
                   Subject Matter Expert
                 </h3>
-                <span class="font-mono text-sm text-stone-500 dark:text-stone-400 whitespace-nowrap">
+                <span class="font-mono text-xs text-stone-500 dark:text-stone-400 whitespace-nowrap">
                   September 2025 - December 2025
                 </span>
               </div>
-              <p class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
+              <p class="font-space text-xs sm:text-sm text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
                 PESU I/O: A Peer-to-Peer Learning Platform
               </p>
-              <p class="font-space text-sm text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
+              <p class="font-space text-xs text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
                 Taught a course on "Foundations of Neural Networks and Deep Learning" to ~50 students
               </p>
             </div>
@@ -237,14 +237,14 @@ import Layout from '../layouts/Layout.astro';
           <div class="flex flex-col sm:flex-row sm:items-start gap-3 sm:gap-4">
             <div class="flex flex-row sm:flex-col items-center gap-3 sm:gap-0">
               <div class="flex-shrink-0 w-10 h-10 sm:w-14 sm:h-14 rounded-lg overflow-hidden border border-stone-200/50 dark:border-stone-700/50">
-                <img 
-                  src="/images/crais.jpeg" 
-                  alt="CRAIS Logo" 
+                <img
+                  src="/images/crais.jpeg"
+                  alt="CRAIS Logo"
                   class="w-full h-full object-cover"
                 />
               </div>
               <div class="sm:hidden flex-1">
-                <h3 class="font-space text-base font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-sm font-medium text-stone-900 dark:text-stone-100">
                   Summer Intern
                 </h3>
                 <span class="font-mono text-xs text-stone-500 dark:text-stone-400">
@@ -254,17 +254,17 @@ import Layout from '../layouts/Layout.astro';
             </div>
             <div class="flex-grow">
               <div class="hidden sm:flex flex-row items-center justify-between gap-2 mb-1">
-                <h3 class="font-space text-lg sm:text-xl font-medium text-stone-900 dark:text-stone-100">
+                <h3 class="font-space text-base sm:text-lg font-medium text-stone-900 dark:text-stone-100">
                   Summer Intern
                 </h3>
-                <span class="font-mono text-sm text-stone-500 dark:text-stone-400 whitespace-nowrap">
+                <span class="font-mono text-xs text-stone-500 dark:text-stone-400 whitespace-nowrap">
                   June 2025 - August 2025
                 </span>
               </div>
-              <p class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
+              <p class="font-space text-xs sm:text-sm text-stone-700 dark:text-stone-300 font-medium mt-1 sm:mt-0">
                 Center for Robotics, Automation and Intelligent Systems
               </p>
-              <p class="font-space text-sm text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
+              <p class="font-space text-xs text-stone-600 dark:text-stone-400 mt-1 sm:mt-2">
                 Implemented RL algorithms for robotic control and autonomous navigation.
               </p>
             </div>
@@ -274,12 +274,12 @@ import Layout from '../layouts/Layout.astro';
 
 
         <!-- Projects Section -->
-        <section class="group relative p-6 sm:p-8 rounded-2xl 
+        <section class="group relative p-6 sm:p-8 rounded-2xl
           bg-gradient-to-br from-rose-50/80 via-white to-rose-100/60
           shadow-[0_15px_35px_-5px_rgb(0,0,0,0.1)]
           border border-rose-300
           backdrop-blur-sm
-          dark:from-stone-900/60 dark:to-stone-800/40 
+          dark:from-stone-900/60 dark:to-stone-800/40
           dark:border-stone-500/60
           hover:shadow-lg hover:border-rose-400 dark:hover:border-stone-500/75 transition-all duration-500">
           <div class="absolute -top-4 -left-4 w-20 h-20 bg-gradient-to-br from-stone-100/20 to-transparent rounded-full blur-lg dark:from-stone-800/15" />
@@ -287,29 +287,29 @@ import Layout from '../layouts/Layout.astro';
           <div class="absolute inset-0 bg-gradient-to-br from-stone-50/20 to-transparent dark:from-stone-900/15 rounded-2xl" />
           <div class="flex items-center justify-between mb-6 sm:mb-8">
             <div class="flex items-center gap-3">
-              <h2 class="font-zt text-2xl sm:text-3xl relative group">
+              <h2 class="font-zt text-xl sm:text-2xl relative group">
                 <span class="relative z-10 text-stone-900 dark:text-stone-100">Projects</span>
                 <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
               </h2>
             </div>
-            <span class="font-space text-xs sm:text-sm text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
+            <span class="font-space text-xs text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
               Featured Work
             </span>
           </div>
           <ul class="space-y-4 sm:space-y-5">
             <li class="relative pl-5 sm:pl-6 before:absolute before:left-0 before:top-2.5 before:w-1.5 before:h-1.5 before:bg-stone-400 dark:before:bg-stone-500 before:rounded-full hover:before:bg-stone-600 dark:hover:before:bg-stone-400 transition-colors">
-              <a 
-                href="/project#main" 
-                class="font-space text-base sm:text-lg text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
+              <a
+                href="/project#main"
+                class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
               >
                 Main projects
                 <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>
               </a>
             </li>
             <li class="relative pl-5 sm:pl-6 before:absolute before:left-0 before:top-2.5 before:w-1.5 before:h-1.5 before:bg-stone-400 dark:before:bg-stone-500 before:rounded-full hover:before:bg-stone-600 dark:hover:before:bg-stone-400 transition-colors">
-              <a 
-                href="/project#side" 
-                class="font-space text-base sm:text-lg text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
+              <a
+                href="/project#side"
+                class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
               >
                 Side projects
                 <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>
@@ -318,12 +318,12 @@ import Layout from '../layouts/Layout.astro';
           </ul>
         </section>
         <!-- Blogs Section -->
-        <section class="group relative p-6 sm:p-8 rounded-2xl 
+        <section class="group relative p-6 sm:p-8 rounded-2xl
           bg-gradient-to-br from-rose-50/80 via-white to-rose-100/60
           shadow-[0_15px_35px_-5px_rgb(0,0,0,0.1)]
           border border-rose-300
           backdrop-blur-sm
-          dark:from-stone-900/60 dark:to-stone-800/40 
+          dark:from-stone-900/60 dark:to-stone-800/40
           dark:border-stone-500/60
           hover:shadow-lg hover:border-rose-400 dark:hover:border-stone-500/75 transition-all duration-500">
           <div class="absolute -top-4 -left-4 w-20 h-20 bg-gradient-to-br from-stone-100/20 to-transparent rounded-full blur-lg dark:from-stone-800/15" />
@@ -331,29 +331,29 @@ import Layout from '../layouts/Layout.astro';
           <div class="absolute inset-0 bg-gradient-to-br from-stone-50/20 to-transparent dark:from-stone-900/15 rounded-2xl" />
           <div class="flex items-center justify-between mb-6 sm:mb-8">
             <div class="flex items-center gap-3">
-              <h2 class="font-zt text-2xl sm:text-3xl relative group">
+              <h2 class="font-zt text-xl sm:text-2xl relative group">
                 <span class="relative z-10 text-stone-900 dark:text-stone-100">Blogs</span>
                 <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
               </h2>
             </div>
-            <span class="font-space text-xs sm:text-sm text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
+            <span class="font-space text-xs text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
               Latest Insights
             </span>
           </div>
           <ul class="space-y-4 sm:space-y-5">
             <li class="relative pl-5 sm:pl-6 before:absolute before:left-0 before:top-2.5 before:w-1.5 before:h-1.5 before:bg-stone-400 dark:before:bg-stone-500 before:rounded-full hover:before:bg-stone-600 dark:hover:before:bg-stone-400 transition-colors">
-              <a 
-                href="/blogs" 
-                class="font-space text-base sm:text-lg text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
+              <a
+                href="/blogs"
+                class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
               >
                 Machine learning
                 <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>
               </a>
             </li>
             <li class="relative pl-5 sm:pl-6 before:absolute before:left-0 before:top-2.5 before:w-1.5 before:h-1.5 before:bg-stone-400 dark:before:bg-stone-500 before:rounded-full hover:before:bg-stone-600 dark:hover:before:bg-stone-400 transition-colors">
-              <a 
-                href="/blogs" 
-                class="font-space text-base sm:text-lg text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
+              <a
+                href="/blogs"
+                class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
               >
                 Writings
                 <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>
@@ -363,12 +363,12 @@ import Layout from '../layouts/Layout.astro';
         </section>
 
         <!-- Ongoings Section -->
-        <section class="group relative p-6 sm:p-8 rounded-2xl 
+        <section class="group relative p-6 sm:p-8 rounded-2xl
           bg-gradient-to-br from-rose-50/80 via-white to-rose-100/60
           shadow-[0_15px_35px_-5px_rgb(0,0,0,0.1)]
           border border-rose-300
           backdrop-blur-sm
-          dark:from-stone-900/60 dark:to-stone-800/40 
+          dark:from-stone-900/60 dark:to-stone-800/40
           dark:border-stone-500/60
           hover:shadow-lg hover:border-rose-400 dark:hover:border-stone-500/75 transition-all duration-500">
           <div class="absolute -top-4 -left-4 w-20 h-20 bg-gradient-to-br from-stone-100/20 to-transparent rounded-full blur-lg dark:from-stone-800/15" />
@@ -376,15 +376,15 @@ import Layout from '../layouts/Layout.astro';
           <div class="absolute inset-0 bg-gradient-to-br from-stone-50/20 to-transparent dark:from-stone-900/15 rounded-2xl" />
           <div class="flex items-center justify-between mb-6 sm:mb-8">
             <div class="flex items-center gap-3">
-              <h2 class="font-zt text-2xl sm:text-3xl relative group">
+              <h2 class="font-zt text-xl sm:text-2xl relative group">
                 <span class="relative z-10 text-stone-900 dark:text-stone-100">Ongoings</span>
                 <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
               </h2>
-              <span class="font-mono  hidden sm:inline text-xs sm:text-sm px-3 py-1 bg-stone-100/80 dark:bg-stone-800/60 text-stone-600 dark:text-stone-400 rounded-full border border-stone-200/50 dark:border-stone-700/50">
+              <span class="font-mono  hidden sm:inline text-xs px-3 py-1 bg-stone-100/80 dark:bg-stone-800/60 text-stone-600 dark:text-stone-400 rounded-full border border-stone-200/50 dark:border-stone-700/50">
                 2 updates
               </span>
             </div>
-            <span class="font-space text-xs sm:text-sm text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
+            <span class="font-space text-xs text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
               Current Focus
             </span>
           </div>
@@ -393,10 +393,10 @@ import Layout from '../layouts/Layout.astro';
                mastering machine learning, completed supervised learning from <span class="text-stone-800 dark:text-stone-200 font-medium">deeplearning.ai</span>,  currently exploring neural networks.
             </p>
 */}
-           <p class="font-space text-stone-600 dark:text-stone-400 text-base sm:text-lg leading-relaxed">
+           <p class="font-space text-stone-600 dark:text-stone-400 text-sm sm:text-base leading-relaxed">
   joined <a href="https://rowboatlabs.com" target="_blank" rel="noopener noreferrer" class="text-stone-800 dark:text-stone-200 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group font-medium">Rowboat Labs (YC S24)<span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span></a> as an AI Engineer.
 </p>
-            <p class="font-space text-stone-600 dark:text-stone-400 text-base sm:text-lg leading-relaxed">
+            <p class="font-space text-stone-600 dark:text-stone-400 text-sm sm:text-base leading-relaxed">
               check out my recent blog on neural networks at the <a href="/blogs" class="text-stone-800 dark:text-stone-200 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group font-medium">
                 blog page
                 <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>
@@ -406,31 +406,31 @@ import Layout from '../layouts/Layout.astro';
         </section>
 
                    <!-- Research Section -->
-<section id="research" class="group relative p-6 sm:p-8 rounded-2xl 
+<section id="research" class="group relative p-6 sm:p-8 rounded-2xl
   bg-gradient-to-br from-rose-50/80 via-white to-rose-100/60
   shadow-[0_15px_35px_-5px_rgb(0,0,0,0.1)]
   border border-rose-300
   backdrop-blur-sm
-  dark:from-stone-900/60 dark:to-stone-800/40 
+  dark:from-stone-900/60 dark:to-stone-800/40
   dark:border-stone-500/60
   hover:shadow-lg hover:border-rose-400 dark:hover:border-stone-500/75 transition-all duration-500">
   <div class="absolute -top-4 -left-4 w-20 h-20 bg-gradient-to-br from-stone-100/20 to-transparent rounded-full blur-lg dark:from-stone-800/15" />
   <div class="absolute -bottom-4 -right-4 w-20 h-20 bg-gradient-to-tr from-rose-100/15 to-transparent rounded-full blur-lg dark:from-rose-900/10" />
   <div class="absolute inset-0 bg-gradient-to-br from-stone-50/20 to-transparent dark:from-stone-900/15 rounded-2xl" />
-  
+
   <div class="flex items-center justify-between mb-6 sm:mb-8">
     <div class="flex items-center gap-3">
-      <h2 class="font-zt text-2xl sm:text-3xl relative group">
+      <h2 class="font-zt text-xl sm:text-2xl relative group">
         <span class="relative z-10 text-stone-900 dark:text-stone-100">Research</span>
         <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
       </h2>
     </div>
-    <span class="font-space text-xs sm:text-sm text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
+    <span class="font-space text-xs text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
       Academic Work
     </span>
   </div>
-  
-  <p class="font-space text-stone-600 dark:text-stone-400 text-base sm:text-lg leading-relaxed italic">
+
+  <p class="font-space text-stone-600 dark:text-stone-400 text-sm sm:text-base leading-relaxed italic">
     Coming soon...
   </p>
 </section>
@@ -450,12 +450,12 @@ import Layout from '../layouts/Layout.astro';
 
   <div class="flex items-center justify-between mb-6 sm:mb-8">
     <div class="flex items-center gap-3">
-      <h2 class="font-zt text-2xl sm:text-3xl relative group">
+      <h2 class="font-zt text-xl sm:text-2xl relative group">
         <span class="relative z-10 text-stone-900 dark:text-stone-100">Notes</span>
         <span class="absolute -bottom-1 left-0 w-full h-0.5 bg-gradient-to-r from-rose-400/40 to-transparent dark:from-rose-500/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></span>
       </h2>
     </div>
-    <span class="font-space text-xs sm:text-sm text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
+    <span class="font-space text-xs text-stone-400 dark:text-stone-500 group-hover:text-stone-600 dark:group-hover:text-stone-400 transition-colors">
       Quick References
     </span>
   </div>
@@ -464,7 +464,7 @@ import Layout from '../layouts/Layout.astro';
     <li class="relative pl-5 sm:pl-6 before:absolute before:left-0 before:top-2.5 before:w-1.5 before:h-1.5 before:bg-stone-400 dark:before:bg-stone-500 before:rounded-full hover:before:bg-stone-600 dark:hover:before:bg-stone-400 transition-colors">
       <a
         href="/notes"
-        class="font-space text-base sm:text-lg text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
+        class="font-space text-sm sm:text-base text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors relative group"
       >
         3rd Semester
         <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-stone-600 dark:bg-stone-400 group-hover:w-full transition-all duration-300"></span>


### PR DESCRIPTION
Shifts the entire type scale on the homepage (`src/pages/index.astro`) down one step so everything reads a touch smaller, keeping the responsive proportions intact:

- Hero heading `text-[2.5rem] sm:text-6xl` → `text-[2rem] sm:text-5xl`
- Section headings `text-2xl sm:text-3xl` → `text-xl sm:text-2xl`
- Body paragraphs & list links `text-base sm:text-lg` → `text-sm sm:text-base`
- Job titles, buttons, dates, descriptions, small labels each stepped down one level

Profile pictures were left at their original committed sizes. This PR exists to generate a Netlify Deploy Preview for testing on other devices before deciding whether to ship to gaganp.com.